### PR TITLE
[API-668] Return the evaluaed content from isArray

### DIFF
--- a/src/main/javascript/view/ParameterView.js
+++ b/src/main/javascript/view/ParameterView.js
@@ -4,9 +4,9 @@ SwaggerUi.Views.ParameterView = Backbone.View.extend({
   initialize: function(){
     Handlebars.registerHelper('isArray', function(param, opts) {
       if (param.type.toLowerCase() === 'array' || param.allowMultiple) {
-        opts.fn(this);
+        return opts.fn(this);
       } else {
-        opts.inverse(this);
+        return opts.inverse(this);
       }
     });
   },


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/API-668

The `isArray` helper never returned its content, so it always evaluated to empty content. (This is *only* used to render multi-select lists, so you could only get single-selection lists.)