### PR TITLE
[API-674] specify spec location from index

### DIFF
--- a/src/main/html/config.js
+++ b/src/main/html/config.js
@@ -1,5 +1,9 @@
 $(function () {
-  var url = "/output.json";
+  var url;
+  if (typeof swaggerSpec === 'undefined')
+    url = '/output.json';
+  else
+    url = swaggerSpec;
 
   window.swaggerUi = new SwaggerUi({
     url: url,


### PR DESCRIPTION
Allows person embedding swagger-ui to specify just the location of the swagger file. This is necessary because we are going to embed this into readme.io