### PR TITLE
use pd/swagger-js by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "less": "^2.4.0",
     "mocha": "^2.1.0",
     "selenium-webdriver": "^2.45.0",
-    "swagger-client": "2.1.11"
+    "swagger-client": "git+https://github.com/PagerDuty/swagger-js.git"
   }
 }


### PR DESCRIPTION
This fixes the schema indentation problem.

![screen shot 2016-02-23 at 5 07 57 pm](https://cloud.githubusercontent.com/assets/8788114/13272316/056e85cc-da50-11e5-8433-ed56105d02e5.png)
