### PR TITLE
[API-681] Show the parameter location ("in")

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -236,6 +236,11 @@
     margin-right: 5px
 }
 
+.swagger-section .parameter-item .small-description .parameter-location {
+    display: inline-table;
+    font-style: italic;
+}
+
 .swagger-section .parameter-item .small-description .markdown {
     display: inline-table;
 }

--- a/src/main/template/param.handlebars
+++ b/src/main/template/param.handlebars
@@ -18,6 +18,9 @@
             {{#if type}}
                 <code class="code-signature">{{type}}</code>
             {{/if}}
+            {{#if in}}
+                <div class="parameter-location">in {{in}}</div>
+            {{/if}}
             <div class="markdown">{{description}}</div>
         </div>
     {{else}}
@@ -38,6 +41,9 @@
         <div class="small-description">
             {{#if type}}
                 <code class="code-signature">{{type}}</code>
+            {{/if}}
+            {{#if in}}
+                <div class="parameter-location">in {{in}}</div>
             {{/if}}
             <div class="markdown">{{description}}</div>
         </div>

--- a/src/main/template/param_list.handlebars
+++ b/src/main/template/param_list.handlebars
@@ -21,6 +21,9 @@
             {{#if type}}
                 <code class="code-signature">{{type}}</code>
             {{/if}}
+            {{#if in}}
+                <div class="parameter-location">in {{in}}</div>
+            {{/if}}
             <div class="markdown">{{description}}</div>
         </div>
     </div>

--- a/src/main/template/param_readonly.handlebars
+++ b/src/main/template/param_readonly.handlebars
@@ -15,6 +15,9 @@
             {{#if type}}
                 <code class="code-signature">{{type}}</code>
             {{/if}}
+            {{#if in}}
+                <div class="parameter-location">in {{in}}</div>
+            {{/if}}
             <div class="markdown">{{description}}</div>
         </div>
     </div>

--- a/src/main/template/param_readonly_required.handlebars
+++ b/src/main/template/param_readonly_required.handlebars
@@ -15,6 +15,9 @@
             {{#if type}}
                 <code class="code-signature">{{type}}</code>
             {{/if}}
+            {{#if in}}
+                <div class="parameter-location">in {{in}}</div>
+            {{/if}}
             <div class="markdown">{{description}}</div>
         </div>
     </div>

--- a/src/main/template/param_required.handlebars
+++ b/src/main/template/param_required.handlebars
@@ -27,6 +27,9 @@
         {{#if type}}
             <code class="code-signature">{{type}}</code>
         {{/if}}
+        {{#if in}}
+            <div class="parameter-location">in {{in}}</div>
+        {{/if}}
         <div class="markdown">{{description}}</div>
     </div>
 </div>


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/API-681

Display the parameter's location as "in *location*", as italic text next to the parameter type:

![image](https://cloud.githubusercontent.com/assets/654641/13302384/7b0709e0-dafe-11e5-88e8-e1a67cff3224.png)
