### PR TITLE
Prevent a default url anchor on init

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -134,12 +134,6 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       $('.optionsWrapper', $(this)).hide();
     });
 
-    if (window.location.hash.length === 0 ) {
-      var n = $(this.el).find("#resources_nav [data-resource]").first();
-      n.trigger("click");
-      $(window).scrollTop(0)
-    }
-
     return this;
   },
 


### PR DESCRIPTION
This will prevent the annoying `/#!/Escalation_Policies/get_escalation_policies` from showing up on initial loading of the page.