### PR TITLE
Override styles for CM

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1,3 +1,6 @@
+.swagger-section {
+    overflow-y: auto !important;
+}
 .swagger-section pre code {
     display: block;
     padding: .5em

--- a/src/main/html/css/index.css
+++ b/src/main/html/css/index.css
@@ -17414,3 +17414,18 @@ li.L9 {
         display: none;
     }
 }
+/* Overrides for content management*/
+li {
+    margin: 0px 0 !important;
+}
+.nav > li {
+    font-family: 'lucida grande',tahoma,verdana,arial,sans-serif;
+}
+.container {
+    width: 100% !important;
+}
+.modal-dialog {
+    position: static !important;
+    width: auto !important;
+    max-width: 1000px !important;
+}


### PR DESCRIPTION
This does not cause any regressions for a stand alone swagger-ui deployment. For content manager use only.