### PR TITLE
[API-662] Clicking on a resource header should show the resource description

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -181,6 +181,7 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       },
       attributes: {
         "data-resource": 'resource_' + resource.name,
+        "data-endpoint": 'resource_' + resource.id,
         "label": resource.name
       },
       router: this.router,
@@ -198,12 +199,8 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
   },
 
   clickResource: function (e) {
-    if (!$(e.target).is(".item")) {
-      var n = $(e.target).find(".item").first();
-      $('.sticky-nav').find("[data-resource].active").removeClass("active");
-      $(e.target).find("[data-resource]").first().addClass("active");
-      n.trigger("click")
-    }
+    $('.sticky-nav').removeClass("nav-open")
+    return false;
   },
 
   toggleToken: function (e) {

--- a/src/main/javascript/view/SidebarHeaderView.js
+++ b/src/main/javascript/view/SidebarHeaderView.js
@@ -7,6 +7,7 @@ SwaggerUi.Views.SidebarHeaderView = Backbone.View.extend({
   },
 
   events: {
+    'click': 'clickSidebarHeader',
     'click [data-endpoint]': 'clickSidebarItem'
   },
 
@@ -37,16 +38,31 @@ SwaggerUi.Views.SidebarHeaderView = Backbone.View.extend({
     $(this.el).append(sidebarItemView.render().el);
   },
 
-  clickSidebarItem: function (e) {
-
+  clickSidebarHeader: function (e) {
     var elem = $(e.target);
-    var eln = $("#" + elem.attr("data-endpoint"));
+
+    if (elem.data("resource")) {
+      return !this.activate(elem);
+    }
+    return true;
+  },
+
+  clickSidebarItem: function (e) {
+    var elem = $(e.target);
 
     if (elem.is(".item")) {
-      scroll(elem.attr("data-endpoint"));
-      setSelected(elem);
-      updateUrl(eln.find(".path a").first().attr("href"))
+      return !this.activate(elem);
     }
+    return true;
+  },
+
+  activate: function (elem) {
+    var eln = $("#" + elem.attr("data-endpoint"));
+
+    scroll(elem.attr("data-endpoint"));
+    setSelected(elem);
+    updateUrl(eln.find(".path a").first().attr("href"))
+    return matchMedia();
 
     /* scroll */
     function scroll(elem) {

--- a/src/main/template/resource.handlebars
+++ b/src/main/template/resource.handlebars
@@ -1,6 +1,6 @@
-<div class="resource_header">
+<a name="resource_{{id}}_header" class="resource_header">
  <h2 class="resource_name">{{tag}}</h2>
  <div class="resource_description markdown">{{description}}</div>
-</div>
+</a>
 <ul class='endpoints' id='{{id}}_endpoint_list'>
 </ul>


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/API-682

Clicking on a tag/resource header (like "Log Entries") previously scrolled to the first endpoint on the resource.

Now that resource descriptions are visible we should scroll to the resource's header in the main window, displaying the description near the top.

Clicking on an endpoint (like "List log entries") should still go to the endpoint definition.