### PR TITLE
[API-690] Start sample sections collapsed

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -948,6 +948,15 @@
 }
 */
 
+.swagger-section .operations .samples h4.collapsed:before {
+    content: "\25B7";
+    padding: 1ex;
+}
+.swagger-section .operations .samples h4:not(.collapsed):before {
+    content: "\25BD";
+    padding: 1ex;
+}
+
 .swagger-section .operations h4:not(.collapsed):after {
     content: "\E17A";
     font-family: budicon-font !important;

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -957,6 +957,10 @@
     padding: 1ex;
 }
 
+.swagger-section .operations .samples h4[data-toggle="collapse"] {
+    cursor: pointer;
+}
+
 .swagger-section .operations h4:not(.collapsed):after {
     content: "\E17A";
     font-family: budicon-font !important;

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -207,6 +207,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     }
 
     if (signatureModel) {
+      signatureModel.collapsed = (this.model.method != 'get');
       responseSignatureView = new SwaggerUi.Views.SignatureView({
         model: signatureModel,
         router: this.router,
@@ -244,7 +245,8 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       isParam: true,
       signature: param.signature,
       type: "Body",
-      id: this.parentId + '_' + this.nickname + '_body'
+      id: this.parentId + '_' + this.nickname + '_body',
+      collapsed: (this.model.method === 'get')
     };
     var signatureView = new SwaggerUi.Views.SignatureView({model: bodySample, tagName: 'div'});
     $('.model-signature', $(this.el)).append(signatureView.render().el);

--- a/src/main/javascript/view/SignatureView.js
+++ b/src/main/javascript/view/SignatureView.js
@@ -5,7 +5,7 @@ SwaggerUi.Views.SignatureView = Backbone.View.extend({
     'mousedown .snippet': 'snippetToTextArea'
   },
 
-  initialize: function () {
+  initialize: function (options) {
   },
 
   render: function () {

--- a/src/main/template/signature.handlebars
+++ b/src/main/template/signature.handlebars
@@ -1,15 +1,15 @@
-<h4 class="sample-title collapsed" data-control data-toggle="collapse"
+<h4 class="sample-title {{#if collapsed}}collapsed{{/if}}" data-control data-toggle="collapse"
     data-target="#sample-{{id}}">{{type}} Sample</h4>
-<div data-content class="collapse" id="sample-{{id}}">
+<div data-content class="collapse {{#unless collapsed}}in{{/unless}}" id="sample-{{id}}">
     <div class="snippet">
         <pre><code>{{sampleJSON}}</code></pre>
     </div>
 </div>
 
 {{#if signature}}
-    <h4 class="schema-title collapsed" data-control data-toggle="collapse"
+    <h4 class="schema-title {{#if collapsed}}collapsed{{/if}}" data-control data-toggle="collapse"
         data-target="#schema-{{id}}">{{type}} Schema</h4>
-    <div data-content class="collapse" id="schema-{{id}}">
+    <div data-content class="collapse {{#unless collapsed}}in{{/unless}}" id="schema-{{id}}">
         <div class="description">
             {{{signature}}}
         </div>

--- a/src/main/template/signature.handlebars
+++ b/src/main/template/signature.handlebars
@@ -1,15 +1,15 @@
-<h4 class="sample-title" data-control data-toggle="collapse"
+<h4 class="sample-title collapsed" data-control data-toggle="collapse"
     data-target="#sample-{{id}}">{{type}} Sample</h4>
-<div data-content class="collapse in" id="sample-{{id}}">
+<div data-content class="collapse" id="sample-{{id}}">
     <div class="snippet">
         <pre><code>{{sampleJSON}}</code></pre>
     </div>
 </div>
 
 {{#if signature}}
-    <h4 class="schema-title" data-control data-toggle="collapse"
+    <h4 class="schema-title collapsed" data-control data-toggle="collapse"
         data-target="#schema-{{id}}">{{type}} Schema</h4>
-    <div data-content class="collapse in" id="schema-{{id}}">
+    <div data-content class="collapse" id="schema-{{id}}">
         <div class="description">
             {{{signature}}}
         </div>


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/API-690

Start with all the sample/schema sections collapsed.
Also added a triangle like ▷ or ▽ before the header, like this:

![image](https://cloud.githubusercontent.com/assets/654641/13335469/2440c696-dbc6-11e5-97b9-43b9710415c0.png)
