### PR TITLE
Revert "Prevent a default url anchor on init"

### DIFF
--- a/src/main/javascript/view/MainView.js
+++ b/src/main/javascript/view/MainView.js
@@ -134,6 +134,12 @@ SwaggerUi.Views.MainView = Backbone.View.extend({
       $('.optionsWrapper', $(this)).hide();
     });
 
+    if (window.location.hash.length === 0 ) {
+      var n = $(this.el).find("#resources_nav [data-resource]").first();
+      n.trigger("click");
+      $(window).scrollTop(0)
+    }
+
     return this;
   },
 


### PR DESCRIPTION
Reverts PagerDuty/swagger-ui#13

With the top "reference" tag being hidden, this does what we need it to do.
It's a little ugly, yes (default hashbang is `#!/API_Reference/get_api_reference`), but it works.