### PR TITLE
Add padding to the bottom of the nav list

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1141,6 +1141,7 @@
     width: 100%;
     z-index: 600;
     border-right: 1px solid #e8eaeb;
+    padding-bottom: 40px;
 }
 
 @media (min-width: 992px) {


### PR DESCRIPTION
Prevents the absolutely-positioned footer with 40px height from making the last entry in the list inaccessible.