### PR TITLE
Scroll up to request fields that have failed validation

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -287,7 +287,14 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     form.find('input.required').each(function () {
       $(this).removeClass('error');
       if (jQuery.trim($(this).val()) === '') {
+        var formTop = $(this).parents('form').offset().top;
         $(this).addClass('error');
+        if ($('body').scrollTop() > formTop) {
+          // scroll the required fields into view
+          $('body').animate({
+            scrollTop: formTop
+          }, 200);
+        }
         $(this).wiggle({
           callback: (function (_this) {
             return function () {


### PR DESCRIPTION
Prevents a jarring jump to a different section of the page and loss of positional context.

![scroll-validation-errors](https://cloud.githubusercontent.com/assets/1423851/13445492/45444fb2-dfc1-11e5-9fe0-3e09b141d499.gif)