### PR TITLE
[API-704] Show alternatives for polymorphic properties

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -430,32 +430,32 @@
     }
 }
 
-.swagger-section .operations .model-signature .description > div {
+.swagger-section .operations .model-signature .description .model > div {
     margin: 0;
     padding: 15px 20px
 }
 
-.swagger-section .operations .model-signature .description > div:after {
+.swagger-section .operations .model-signature .description .model > div:after {
     clear: both
 }
 
-.swagger-section .operations .model-signature .description > div:after, .swagger-section .operations .model-signature .description > div:before {
+.swagger-section .operations .model-signature .description .model > div:after, .swagger-section .operations .model-signature .description .model > div:before {
     content: "";
     display: table
 }
 
 @media (min-width: 1400px) {
-    .swagger-section .operations .model-signature .description > div {
+    .swagger-section .operations .model-signature .description .model > div {
         padding: 15px 30px
     }
 }
 
-.swagger-section .operations .model-signature .description > div + div {
+.swagger-section .operations .model-signature .description .model > div + div {
     border-top: 1px solid #717d88
 }
 
 @media (min-width: 992px) {
-    .swagger-section .operations .model-signature .description > div + div {
+    .swagger-section .operations .model-signature .description .model > div + div {
         border-top: 1px solid #5c666f
     }
 }

--- a/src/main/html/restyle.js
+++ b/src/main/html/restyle.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
   /* Bootstrapping */
 
-  var targetContainerClass = '.model-signature .description';
+  var targetContainerClass = '.model-signature .description .model';
 
   waitUntilModelSignatureElementsExist();
 

--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -5,3 +5,11 @@ Handlebars.registerHelper('sanitize', function(html) {
     html = html.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
     return new Handlebars.SafeString(html);
 });
+Handlebars.registerHelper('times', function(n, html) {
+  var sum = '';
+
+  for (var i = 0; i < n; i++) {
+    sum += html.fn(i);
+  }
+  return sum;
+});

--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -181,8 +181,10 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
             isParam: false,
             signature: value.getMockSignature(),
             type: "Response",
-            id: this.parentId + '_' + this.nickname + '_succes'
+            id: this.parentId + '_' + this.nickname + '_succes',
+            polymorphic: this.assemblePolymorphics(value)
           };
+
         }
       }
     } else if (this.model.responseClassSignature && this.model.responseClassSignature !== 'string') {
@@ -237,6 +239,49 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     return this;
   },
 
+  assemblePolymorphics: function (model) {
+    var polymorphic = {};
+
+    for (var prop in model.definition.properties) {
+      var defn = model.definition.properties[prop];
+      var ref = (defn.type == 'array' && defn.items ? defn.items.$ref : defn.$ref);
+
+      if (ref && ref.indexOf('#/definitions/') == 0) {
+        var type = ref.substring('#/definitions/'.length);
+        var subclasses = this.findSubclasses(model.models, ref);
+        if (subclasses.length > 1) {
+          polymorphic[type] = subclasses.sort(function(model1, model2) {
+            return model1.name.localeCompare(model2.name)
+          }).map(function(model) {
+            return {
+              id: model.definition.id,
+              name: model.name,
+              selected: (model.name == type),
+              content: model.getMockSignature()
+            };
+          });
+        }
+      }
+    }
+
+    return polymorphic;
+  },
+
+  findSubclasses: function (models, target) {
+    var subclasses = [];
+
+    for (var modelName in models) {
+      var model = models[modelName];
+      var resolved = model.definition && model.definition['x-resolved-from'];
+
+      if (resolved && resolved.includes(target)) {
+        subclasses.push(model);
+      }
+    }
+
+    return subclasses;
+  },
+
   addBodyModel: function (param) {
     if (param.type === 'file') return;
 
@@ -248,6 +293,16 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
       id: this.parentId + '_' + this.nickname + '_body',
       collapsed: (this.model.method === 'get')
     };
+
+    var ref = param.schema.$ref;
+    if (ref && ref.indexOf('#/definitions/') === 0) {
+      var type = ref.substring('#/definitions/'.length);
+      var model = this.model.models[type];
+      if (model) {
+        bodySample.polymorphic = this.assemblePolymorphics(model);
+      }
+    }
+
     var signatureView = new SwaggerUi.Views.SignatureView({model: bodySample, tagName: 'div'});
     $('.model-signature', $(this.el)).append(signatureView.render().el);
   },

--- a/src/main/javascript/view/SignatureView.js
+++ b/src/main/javascript/view/SignatureView.js
@@ -2,7 +2,8 @@
 
 SwaggerUi.Views.SignatureView = Backbone.View.extend({
   events: {
-    'mousedown .snippet': 'snippetToTextArea'
+    'mousedown .snippet': 'snippetToTextArea',
+    'change select.alternatives': 'selectAlternate'
   },
 
   initialize: function (options) {
@@ -11,7 +12,44 @@ SwaggerUi.Views.SignatureView = Backbone.View.extend({
   render: function () {
     $(this.el).html(Handlebars.templates.signature(this.model));
     this.isParam = this.model.isParam;
+
+    if (this.model.polymorphic) {
+      this.wrapPolymorphic();
+    }
+
     return this;
+  },
+
+  wrapPolymorphic: function () {
+    for (var type in this.model.polymorphic) {
+      var alternates  = this.model.polymorphic[type];
+      var defaultAlternate = alternates.find(function(alt) {
+        return alt.selected;
+      });
+      if (defaultAlternate == null) {
+        defaultAlternate = {};
+      }
+
+      var id = this.model.id + '-' + type;
+      var master = $(this.el).find("span.strong:contains('" + type + "')").closest('span.model');
+      var newMaster = Handlebars.templates.signature_alternates({
+        id: id,
+        name: this.model.name,
+        alternates: alternates,
+      });
+      var replacement = master.replaceWith(newMaster);
+
+      this.showAlternate($(this.el).find('form.polymorphic#' + id), defaultAlternate.id);
+    }
+  },
+
+  selectAlternate: function (e) {
+    this.showAlternate($(e.target).closest('form.polymorphic'), e.target.value);
+  },
+
+  showAlternate: function (alternates, type) {
+    alternates.find('.alternate').hide();
+    alternates.find('.alternate_' + type).show();
   },
 
   // handler for snippet to text area

--- a/src/main/javascript/view/SignatureView.js
+++ b/src/main/javascript/view/SignatureView.js
@@ -23,23 +23,16 @@ SwaggerUi.Views.SignatureView = Backbone.View.extend({
   wrapPolymorphic: function () {
     for (var type in this.model.polymorphic) {
       var alternates  = this.model.polymorphic[type];
-      var defaultAlternate = alternates.find(function(alt) {
-        return alt.selected;
-      });
-      if (defaultAlternate == null) {
-        defaultAlternate = {};
-      }
-
       var id = this.model.id + '-' + type;
       var master = $(this.el).find("span.strong:contains('" + type + "')").closest('span.model');
       var newMaster = Handlebars.templates.signature_alternates({
         id: id,
-        name: this.model.name,
+        type: type,
         alternates: alternates,
       });
       var replacement = master.replaceWith(newMaster);
 
-      this.showAlternate($(this.el).find('form.polymorphic#' + id), defaultAlternate.id);
+      this.showAlternate($(this.el).find('form.polymorphic#' + id), alternates[0].id);
     }
   },
 

--- a/src/main/template/signature_alternates.handlebars
+++ b/src/main/template/signature_alternates.handlebars
@@ -1,9 +1,23 @@
 <form id="{{id}}" class="polymorphic">
-    <select class="alternatives form-control">
-        {{#each alternates}}
-            <option value="{{id}}" {{#if selected}}selected="selected"{{/if}}>{{name}}{{#if selected}} *{{/if}}</option>
-        {{/each}}
-    </select>
+    <span class="model">
+        <div>
+            <span class="propLabels">
+                <span class="propType" title="{{type}}">
+                    {{type}}
+                </span>
+                <span class="propPolymorphic">
+                    polymorphic
+                </span>
+            </span>
+            <span class="propDesc">
+                <select class="alternatives form-control">
+                    {{#each alternates}}
+                        <option value="{{id}}" {{#if @first}}selected="selected"{{/if}}>{{#times depth}}&nbsp; {{/times}}{{name}}</option>
+                    {{/each}}
+                </select>
+            </span>
+        </div>
+    </span>
 
     {{#each alternates}}
         <div class="alternate alternate_{{id}}">

--- a/src/main/template/signature_alternates.handlebars
+++ b/src/main/template/signature_alternates.handlebars
@@ -1,0 +1,13 @@
+<form id="{{id}}" class="polymorphic">
+    <select class="alternatives form-control">
+        {{#each alternates}}
+            <option value="{{id}}" {{#if selected}}selected="selected"{{/if}}>{{name}}{{#if selected}} *{{/if}}</option>
+        {{/each}}
+    </select>
+
+    {{#each alternates}}
+        <div class="alternate alternate_{{id}}">
+            {{{content}}}
+        </div>
+    {{/each}}
+</form>


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/API-704

This replaces each base polymorphic class in request and response schema with a drop-list to select alternate types:

![polymorphic](https://cloud.githubusercontent.com/assets/654641/13542443/b3f41f16-e217-11e5-814e-d7e2a0d9e3cd.gif)

Note that this only operates on root objects or arrays, not deeper in the hierarchy. For instance, `ContactMethod` schema will be replaced in the `Contact Method` operations, but not the `User` operations.

This requires [a version of `swagger-js` including this PR](https://github.com/PagerDuty/swagger-js/pull/1).