### PR TITLE
Use Array#indexOf instead of Array#includes for compatibility

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -269,7 +269,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
         var subModel = models[modelName];
         var resolved = subModel.definition && subModel.definition['x-resolved-from'];
 
-        if (resolved && resolved.includes(ref)) {
+        if (resolved && resolved.indexOf(ref) != -1) {
           subclasses = subclasses.concat(this.findSubclasses(models, modelName, depth+1));
         }
       }


### PR DESCRIPTION
It isn't supported by older browsers or by IE at all: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes#Browser_compatibility