### PR TITLE
Allow property names to be wider in response schema

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -505,7 +505,7 @@
     position: relative;
     top: -1px;
     left: 5px;
-    max-width: 150px;
+    max-width: 200px;
     text-overflow: ellipsis;
     overflow: hidden
 }


### PR DESCRIPTION
Changes

![api_explorer](https://cloud.githubusercontent.com/assets/1423851/15951596/a569f2ba-2e6e-11e6-8a9d-cf4268ea12d2.png)

to

![api_explorer](https://cloud.githubusercontent.com/assets/1423851/15951599/a9bf5daa-2e6e-11e6-8f29-d88313d859cf.png)
