### PR TITLE
[PF-152] Call CodeMirror only when needed

### DIFF
--- a/src/main/javascript/view/OperationView.js
+++ b/src/main/javascript/view/OperationView.js
@@ -7,6 +7,7 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     'submit .sandbox': 'submitOperation',
     'click .submit': 'submitOperation',
     'click  a.toggle-samples': 'toggleSamples',
+    'focusin': 'makeCodeMirror',
     'snippet': 'snippetToCodeMirror'
 //    'mouseenter .api-ic': 'mouseEnter',
 //    'mouseout .api-ic': 'mouseExit'
@@ -310,16 +311,27 @@ SwaggerUi.Views.OperationView = Backbone.View.extend({
     var signatureView = new SwaggerUi.Views.SignatureView({model: bodySample, tagName: 'div'});
     $('.model-signature', $(this.el)).append(signatureView.render().el);
 
-    var $editor = this.$el.find('textarea.body-textarea');
-    this.codeMirror = CodeMirror.fromTextArea($editor[0], {json: true});
   },
 
   snippetToCodeMirror: function (e, snippet) {
-    if (this.codeMirror) {
+    var codeMirror = this.getCodeMirror();
+    if (codeMirror) {
       this.codeMirror.setValue(snippet || '');
     }
   },
 
+  makeCodeMirror: function() {
+    getCodeMirror();
+    return true;
+  },
+
+  getCodeMirror: function() {
+    if (!this.codeMirror) {
+      var $editor = this.$el.find('textarea.body-textarea');
+      this.codeMirror = CodeMirror.fromTextArea($editor[0], {json: true});
+    }
+    return this.codeMirror;
+  },
 
   addParameter: function (param, consumes) {
     // Render a parameter


### PR DESCRIPTION
https://pagerduty.atlassian.net/browse/PF-152

In an attempt to speed up loading the swagger docs, I moved the code to CodeMirror-ize the text areas from initialization to the moment a user either:

1. focuses on the textarea or,
2. clicks on the sample JSON.

The page may blink a little, but it does reduce the start-up time locally from almost 1.8 sec to less than 1.3 seconds (as measured by Chrome's "Timeline" view, which excludes server time).

I don't see any other big wins for start-up time, either in our own code, or in the various commits on swagger-js or swagger-ui....