### PR TITLE
[PF-602] Support markdown in status response descriptions

### DIFF
--- a/src/main/template/status_code.handlebars
+++ b/src/main/template/status_code.handlebars
@@ -1,2 +1,2 @@
 <td style="width: 20px;"><strong>{{code}}</strong></td>
-<td>{{{message}}}</td>
+<td class="markdown">{{{message}}}</td>


### PR DESCRIPTION
For [PF-602](https://github.com/PagerDuty/captains-log/pull/266/files#diff-e6e8f28b7dc57fe07e96a79c43df4723R4), I added some markdown to response description for a 402 error:

This PR adds support for markdown there, by adding the class to the message container.