### PR TITLE
Support HEAD operation

### DIFF
--- a/src/main/html/config.js
+++ b/src/main/html/config.js
@@ -36,7 +36,7 @@ $(function () {
     apiKey: apiKey,
     removeApiInput: removeApiInput,
     dom_id: "swagger-ui-container",
-    supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+    supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch', 'head'],
     onComplete: function (swaggerApi, swaggerUi) {
       $('#spinner-container').hide();
 


### PR DESCRIPTION
Allow clients to declare HTTP HEAD operations.
(This is needed to support the permissions API.)