### PR TITLE
Sample button

### DIFF
--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1598,10 +1598,13 @@ body {
 
     .swagger-section #resources a.toggle-samples {
         display: inline-block;
-        position: absolute;
+        position: fixed;
         top: 30px;
         right: 20px;
         color: #5c666f;
+        background: rgba(255, 255, 255, 0.2);
+        padding: 6px;
+        border-radius: 6px;
         text-decoration: none;
         cursor: pointer
     }

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1602,7 +1602,7 @@ body {
         top: 30px;
         right: 20px;
         color: #5c666f;
-        background: rgba(255, 255, 255, 0.2);
+        background: #fff;
         padding: 6px;
         border-radius: 6px;
         text-decoration: none;

--- a/src/main/html/css/api-explorer.css
+++ b/src/main/html/css/api-explorer.css
@@ -1602,8 +1602,8 @@ body {
         top: 30px;
         right: 20px;
         color: #5c666f;
-        background: #fff;
-        padding: 6px;
+        background: rgba(255, 255, 255, 0.8);
+        padding: 6px 8px;
         border-radius: 6px;
         text-decoration: none;
         cursor: pointer

--- a/src/main/javascript/helpers/handlebars.js
+++ b/src/main/javascript/helpers/handlebars.js
@@ -13,3 +13,10 @@ Handlebars.registerHelper('times', function(n, html) {
   }
   return sum;
 });
+Handlebars.registerHelper('if_eq', function(a, b, opts) {
+    if (a == b) {
+        return opts.fn(this);
+    } else {
+        return opts.inverse(this);
+    }
+});

--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -15,10 +15,12 @@
                 </h3>
             </div>
 
+            {{#if_eq parentId 'API_Reference'}}
             <a href="javascript:;" class="toggle-samples" data-toggle="tooltip" data-placement="left"
                data-original-title title>
                 <span class="text">Show samples</span><span class="circle-icon"></span>
             </a>
+            {{/if_eq}}
 
             {{#if deprecated}}
                 <h4>Warning: Deprecated</h4>


### PR DESCRIPTION
Updated the show samples button to stay fixed in the top-right for better visibility. Also resolved the issue where the show samples button would continue to display under collapse samples.