### PR TITLE
Hotfix for missing sample button

### DIFF
--- a/src/main/template/operation.handlebars
+++ b/src/main/template/operation.handlebars
@@ -15,7 +15,7 @@
                 </h3>
             </div>
 
-            {{#if_eq parentId 'API_Reference'}}
+            {{#if_eq parentId 'Abilities'}}
             <a href="javascript:;" class="toggle-samples" data-toggle="tooltip" data-placement="left"
                data-original-title title>
                 <span class="text">Show samples</span><span class="circle-icon"></span>


### PR DESCRIPTION
Switching parent from API_Reference to Abilities so the button displays in prod